### PR TITLE
Development -> master

### DIFF
--- a/sva_frappe/sva_frappe/doctype/sva_user/sva_user.py
+++ b/sva_frappe/sva_frappe/doctype/sva_user/sva_user.py
@@ -4,62 +4,52 @@ from frappe.model.document import Document
 
 class SVAUser(Document):
 	def before_save(self):
-		# Update full name
 		if self.last_name:
 			self.full_name = self.first_name + " " + self.last_name
 		else:
 			self.full_name = self.first_name
 		if isinstance(self.email, tuple):
 			self.email = self.email[0]
-		# Insert new permissions if they don’t exist
-		for table in self.get("table_pdop", []):
-			user_permission = None
-			up_docs = frappe.db.get_list(
-				"User Permission",
-				filters={"user": self.email, "allow": table.module, "for_value": table.value},
-				fields=["name"],
-				limit=1,
-				ignore_permissions=True,
-			)
-			exists = len(up_docs)
-			if not exists:
-				user_permission = frappe.new_doc("User Permission")
-			else:
-				user_permission = frappe.get_doc("User Permission", up_docs[0].name)
 
-			user_permission.user = self.email
-			user_permission.allow = table.module
-			user_permission.for_value = table.value
-			if not exists:
-				new_doc = user_permission.insert(ignore_permissions=True)
-				table.name = new_doc.name
-			else:
-				user_permission.save(ignore_permissions=True)
+		# Reject duplicate (module, value) pairs in the child table
+		seen = set()
+		for row in self.get("table_pdop", []):
+			pair = (row.module, row.value)
+			if pair in seen:
+				frappe.throw(
+					f"Duplicate entry in Data Permissions: <b>{row.module} — {row.value}</b> already exists at row {row.idx}."
+				)
+			seen.add(pair)
 
-		existing_permissions = frappe.get_all(
-			"User Permission", filters={"user": self.email}, fields=["name", "for_value"]
-		)
-
-		existing_for_values = {perm["for_value"]: perm["name"] for perm in existing_permissions}
-		new_for_values = {table.value for table in self.get("table_pdop", [])}
-		# Delete permissions that are not in the child table
-		for for_value, name in existing_for_values.items():
-			if for_value not in new_for_values:
-				frappe.delete_doc("User Permission", name, ignore_permissions=True)
-
-		# List of user-permission names that should exist
-		up_list = [perm["name"] for perm in existing_permissions if perm["for_value"] in new_for_values]
-
-		# Find and delete unallocated permissions
-		unallocated_permissions = frappe.get_list(
+		# Fetch all existing User Permissions for this user in one query
+		all_up = frappe.db.get_all(
 			"User Permission",
-			filters={"name": ["NOT IN", up_list], "user": self.email},
-			pluck="name",
+			filters={"user": self.email},
+			fields=["name", "allow", "for_value"],
 			ignore_permissions=True,
 		)
+		existing_map = {(p.allow, p.for_value): p.name for p in all_up}
 
-		for name in unallocated_permissions:
-			frappe.delete_doc("User Permission", name, ignore_permissions=True)
+		# Guard prevents on_user_permission_change hook from cascading back during our sync
+		frappe.flags.sva_user_permission_syncing = True
+		try:
+			new_pairs = set()
+			for table in self.get("table_pdop", []):
+				pair = (table.module, table.value)
+				new_pairs.add(pair)
+				if not existing_map.get(pair):
+					user_permission = frappe.new_doc("User Permission")
+					user_permission.user = self.email
+					user_permission.allow = table.module
+					user_permission.for_value = table.value
+					user_permission.insert(ignore_permissions=True)
+
+			# Delete User Permissions that are no longer in the child table
+			for (allow, for_value), name in existing_map.items():
+				if (allow, for_value) not in new_pairs:
+					frappe.delete_doc("User Permission", name, ignore_permissions=True)
+		finally:
+			frappe.flags.sva_user_permission_syncing = False
 
 		if self.status == "Inactive" and self.is_verified == 1:
 			self.is_verified = 0
@@ -139,31 +129,37 @@ class SVAUser(Document):
 
 @frappe.whitelist()
 def on_user_permission_change(doc, method):
+	# Skip when SVA User's own before_save is managing permissions — avoids cascade
+	if frappe.flags.get("sva_user_permission_syncing"):
+		return
+
+	sva_user = frappe.db.get_value("SVA User", {"email": doc.user}, "name")
+	if not sva_user:
+		return
+
 	if method == "on_update":
-		_doc = frappe.get_doc("SVA User", {"email": doc.user}, ignore_permissions=True)
-		# Check if the permission already exists
-		new_entry = frappe.get_doc(
-			{
-				"doctype": "User Data Permissions",
-				"parent": _doc.name,
-				"parentfield": "table_pdop",
-				"parenttype": "SVA User",
-				"module": doc.allow,
-				"value": doc.for_value,
-			}
+		exists = frappe.db.exists(
+			"User Data Permissions",
+			{"parent": sva_user, "module": doc.allow, "value": doc.for_value},
 		)
-		new_entry.insert(ignore_permissions=True)
-		frappe.db.commit()
+		if not exists:
+			new_entry = frappe.get_doc(
+				{
+					"doctype": "User Data Permissions",
+					"parent": sva_user,
+					"parentfield": "table_pdop",
+					"parenttype": "SVA User",
+					"module": doc.allow,
+					"value": doc.for_value,
+				}
+			)
+			new_entry.insert(ignore_permissions=True)
 
 	elif method == "on_trash":
-		_doc = frappe.get_doc("SVA User", {"email": doc.user}, ignore_permissions=True)
-
 		permissions_to_delete = frappe.get_all(
 			"User Data Permissions",
-			filters={"parent": _doc.name, "module": doc.allow, "value": doc.for_value},
-			pluck="name",  # Get only the document names
+			filters={"parent": sva_user, "module": doc.allow, "value": doc.for_value},
+			pluck="name",
 		)
-
 		for perm_name in permissions_to_delete:
 			frappe.delete_doc("User Data Permissions", perm_name, ignore_permissions=True)
-		frappe.db.commit()


### PR DESCRIPTION
This pull request refactors the SVA User data permissions synchronization logic to improve efficiency, prevent duplicate entries, and avoid cascading updates between `SVA User` and `User Permission` documents. The changes ensure that user data permissions remain consistent and that unnecessary database operations are minimized.

**Data Permissions Synchronization Improvements:**

- Added a check to prevent duplicate (module, value) pairs in the `table_pdop` child table, throwing an error if duplicates are found.
- Optimized the synchronization of `User Permission` documents by fetching all existing permissions for the user in a single query and maintaining a mapping for efficient lookup and deletion.
- Ensured that only new permissions are inserted and obsolete ones are deleted, reducing redundant database operations.

**Cascade Prevention and Consistency:**

- Introduced a `frappe.flags.sva_user_permission_syncing` guard to prevent the `on_user_permission_change` hook from triggering recursive updates when permissions are being managed by the SVA User's own logic. [[1]](diffhunk://#diff-796208fc5a074fa4fc553c0de84ed4c8ab8f30356f0661d71f1727b0f04ff09eL7-R52) [[2]](diffhunk://#diff-796208fc5a074fa4fc553c0de84ed4c8ab8f30356f0661d71f1727b0f04ff09eR132-L169)
- Updated the `on_user_permission_change` handler to respect the new guard, and refactored it to use the user’s name directly, improving clarity and avoiding unnecessary document fetches.